### PR TITLE
docs: improve `smv_released_pattern` section

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -68,10 +68,10 @@ Here are some examples:
 
 .. code-block:: python
 
-    smv_released_pattern = r'^tags/.*$'           # Tags only
-    smv_released_pattern = r'^heads/\d+\.\d+$'    # Branches like "2.1"
-    smv_released_pattern = r'^(tags/.*|heads/\d+\.\d+)$'           # Branches like "2.1" and all tags
-    smv_released_pattern = r'^(tags|heads|remotes/[^/]+)/(?!master).*$' # Everything except master branch
+    smv_released_pattern = r'^refs/tags/.*$'           # Tags only
+    smv_released_pattern = r'^refs/heads/\d+\.\d+$'    # Branches like "2.1"
+    smv_released_pattern = r'^refs/(tags/.*|heads/\d+\.\d+)$'           # Branches like "2.1" and all tags
+    smv_released_pattern = r'^refs/(tags|heads|remotes/[^/]+)/(?!master).*$' # Everything except master branch
 
 .. note::
 
@@ -79,7 +79,7 @@ Here are some examples:
 
     .. code-block:: bash
 
-        git for-each-ref --format "%(refname)" | sed 's/^refs\///g'
+        git for-each-ref --format "%(refname)"
 
 
 Output Directory Format

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -71,7 +71,7 @@ Here are some examples:
     smv_released_pattern = r'^tags/.*$'           # Tags only
     smv_released_pattern = r'^heads/\d+\.\d+$'    # Branches like "2.1"
     smv_released_pattern = r'^(tags/.*|heads/\d+\.\d+)$'           # Branches like "2.1" and all tags
-    smv_released_pattern = r'^(heads|remotes/[^/]+)/(?!:master).*$' # Everything except master branch
+    smv_released_pattern = r'^(tags|heads|remotes/[^/]+)/(?!master).*$' # Everything except master branch
 
 .. note::
 


### PR DESCRIPTION
1. It says `Everything except master branch`, so, it should include tags.
2. The colon in the negative regex match was probably a typo, as it prevents matching of the `master` branch. With that colon, none of the refs in my repo match and hence all refs are treated as not-released.
3. The example `sed`-s away the `refs/` prefix, but, it seems like `smv_released_pattern` _is_ evaluated against the full refspec, i.e., with `refs/`. Avoid the confusion, or, fix the docs, respectively.

fixes https://github.com/Holzhaus/sphinx-multiversion/issues/66